### PR TITLE
Add check to ensure the data was saved to db correctly when finish processing each comment changeset

### DIFF
--- a/Bugzilla/Bugzilla_mozilla_changeset_contents_scraper.py
+++ b/Bugzilla/Bugzilla_mozilla_changeset_contents_scraper.py
@@ -298,7 +298,7 @@ def get_changeset_properties_rev(request_url):
         
         if response:
             content = response.text
-        else:
+        elif response_status_code and response_status_code != 404:
             content = None
             response_status_code = -1
 

--- a/Bugzilla/Bugzilla_mozilla_changeset_contents_scraper.py
+++ b/Bugzilla/Bugzilla_mozilla_changeset_contents_scraper.py
@@ -1136,13 +1136,12 @@ def start_scraper(task_group, start_row, end_row, scraper_type):
                         continue
 
 
-
 ##################################################################################################### 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="")
     parser.add_argument('arg_1', type=int, help='Argument 1')
-    parser.add_argument('arg_2', type=int, help='Arg ument 2')
+    parser.add_argument('arg_2', type=int, help='Argument 2')
     parser.add_argument('arg_3', type=int, help='Argument 3')
     parser_args = parser.parse_args()
     task_group = parser_args.arg_1

--- a/Bugzilla/Bugzilla_mozilla_changeset_contents_scraper.py
+++ b/Bugzilla/Bugzilla_mozilla_changeset_contents_scraper.py
@@ -64,10 +64,10 @@ get_unprocessed_comment_changesets_query = '''
         ,[Process_Status]
         ,[ID] --unique identifier
     FROM [Temp_Comment_Changesets_For_Process]
-    WHERE Process_Status is null
-    AND Task_Group = ?
-    AND Row_Num BETWEEN ? AND ?
-    ORDER BY Row_Num ASC, Q1_Hash_ID ASC; 
+    WHERE [Process_Status] IS NULL
+    AND [Task_Group] BETWEEN ? AND ?
+    AND [Row_Num] BETWEEN ? AND ?
+    ORDER BY [Task_Group] ASC, [Row_Num] ASC, [Q1_Hash_ID] ASC; 
 '''
 
 save_changeset_parent_child_hashes_query = '''
@@ -551,7 +551,7 @@ def save_changeset_properties(changeset_hash_id, changeset_properties):
         print("\nFailed after maximum retry attempts due to deadlock.")
         exit()
 
-def get_unprocessed_comment_changeset_records(task_group, start_row, end_row):
+def get_unprocessed_comment_changeset_records(task_group_start, task_group_end, start_row, end_row):
     global conn_str, get_unprocessed_comment_changesets_query
     attempt_number = 1
     max_retries = 999 # max retry for deadlock issue.
@@ -561,7 +561,7 @@ def get_unprocessed_comment_changeset_records(task_group, start_row, end_row):
             conn = pyodbc.connect(conn_str)
             cursor = conn.cursor()
 
-            cursor.execute(get_unprocessed_comment_changesets_query, (task_group, start_row, end_row))
+            cursor.execute(get_unprocessed_comment_changesets_query, (task_group_start, task_group_end, start_row, end_row))
             rows = cursor.fetchall()
             return rows
         
@@ -662,6 +662,60 @@ def get_bugzilla_mozilla_changesets_by_hash_id(hash_id):
     else:
         print("\nFailed after maximum retry attempts due to deadlock.")
         exit()
+
+
+def is_temp_comment_changeset_done(id):
+    if not id:
+        return False
+    
+    global conn_str
+    attempt_number = 1
+    max_retries = 5 # max retry for deadlock issue.
+
+    while attempt_number <= max_retries:
+        try:
+            conn = pyodbc.connect(conn_str)
+            cursor = conn.cursor()
+
+            cursor.execute('''
+                SELECT TOP 1 1
+                FROM [dbo].[Temp_Comment_Changesets_For_Process]
+                WHERE [ID] = ?
+                    AND [Process_Status] IS NOT NULL
+                ''', (id))
+            
+            row = cursor.fetchone()
+            if row:
+                return True
+            else:
+                return False
+    
+        except pyodbc.Error as e:
+            error_code = e.args[0]
+            if error_code in ['40001', '40P01']:  # Deadlock error codes
+                attempt_number += 1
+                time.sleep(5)
+                if attempt_number < max_retries:
+                    continue
+            print(f"pyodbc.Error - is_temp_comment_changeset_done({id}): {e}.")
+            traceback.print_exc()
+            return False
+
+        except Exception as e:
+            # Handle any exceptions
+            print(f"Error - is_temp_comment_changeset_done({id}): {e}.")
+            traceback.print_exc()
+            return False
+
+        finally:
+            # Close the cursor and connection if they are not None
+            if cursor:
+                cursor.close()
+            if conn:
+                conn.close()
+    else:
+        print("\nFailed after maximum retry attempts due to deadlock.")
+        return False
 
 
 # save_comment_changeset_properties: this function saves all the properties of the comment changeset after finished processed:
@@ -822,13 +876,6 @@ def save_comment_changeset_properties(process_status, temp_comment_changesets_fo
             mercurial_type_list_string = " | ".join(mercurial_type_list_to_be_saved)
 
             if existing_bug_mozilla_changeset:
-                # cursor.execute('''
-                #     UPDATE [Bugzilla_Mozilla_Changesets]
-                #     SET [Bug_Ids] = ?
-                #         ,[Mercurial_Type] = ?
-                #     WHERE [Hash_ID] = ?
-                #     ''', (bug_ids_list_to_be_saved_string, mercurial_type_list_string, existing_bug_mozilla_changeset.hash_id))
-                
                 query_count += 1
                 save_comment_changeset_properties_queries += '''
                     UPDATE [Bugzilla_Mozilla_Changesets]
@@ -838,36 +885,7 @@ def save_comment_changeset_properties(process_status, temp_comment_changesets_fo
                     WHERE [Hash_ID] = ?;
                     '''
                 params.extend([bug_ids_list_to_be_saved_string, mercurial_type_list_string, existing_bug_mozilla_changeset.hash_id])
-
             else:
-                # cursor.execute('''
-                # INSERT INTO [dbo].[Bugzilla_Mozilla_Changesets]
-                #     ([Hash_Id]
-                #     ,[Changeset_Summary]
-                #     ,[Bug_Ids]
-                #     ,[Mercurial_Type]
-                #     ,[Changeset_Datetime]
-                #     ,[Is_Backed_Out_Changeset]
-                #     ,[Backed_Out_By]
-                #     ,[Backout_Hashes]
-                #     ,[Parent_Hashes]
-                #     ,[Child_Hashes]
-                #     ,[Inserted_On] -- SYSUTCDATETIME()
-                #     ,[Task_Group]) -- NULL
-                # VALUES
-                #     (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, SYSUTCDATETIME(), NULL)
-                # ''', (changeset_properties.hash_id, # Hash_Id
-                #       changeset_properties.changeset_summary_raw_content, # Changeset_Summary
-                #       bug_ids_list_to_be_saved_string, # Bug_Ids
-                #       mercurial_type_list_string, # Mercurial_Type
-                #       changeset_properties.changeset_datetime, # Changeset_Datetime
-                #       changeset_properties.is_backed_out_changeset, # Is_Backed_Out_Changeset
-                #       changeset_properties.backed_out_by, # Backed_Out_By
-                #       changeset_properties.backout_hashes, # Backout_Hashes
-                #       changeset_properties.parent_hashes, # Parent_Hashes
-                #       changeset_properties.child_hashes # Child_Hashes
-                # ))
-
                 query_count += 1
                 save_comment_changeset_properties_queries += '''
                 INSERT INTO [dbo].[Bugzilla_Mozilla_Changesets]
@@ -1025,103 +1043,115 @@ def start_scraper(task_group, start_row, end_row, scraper_type):
             ]
 
             records = get_unprocessed_comment_changeset_records(task_group, start_row, end_row)
-            record_count = len(records)
-
+            total_records = len(records)
             prev_temp_comment_changesets_for_process = None
             prev_changeset_properties = None
+            remaining_records = total_records
+            for i in range(total_records):
+                # While True gives us ability to re-do the iteration. Found that something the data weren't being saved to the db correctly. For such cases, re-do it.
+                re_run_iteration_count = 1
+                while re_run_iteration_count <= 5:
+                    # Define and Convert the record to namedtuple
+                    namedtuple_type = namedtuple('Record', field_names)
+                    temp_comment_changesets_for_process = namedtuple_type(*records[i]) # namedtuple type
+                    process_status = 'Unknown'
+                    changeset_properties = None
+                    print(f"[{strftime('%m/%d/%Y %H:%M:%S', localtime())}] Remainings: {str(remaining_records)}. Process row number {temp_comment_changesets_for_process.row_num}...", end="", flush=True)
 
-            for i in range(record_count):
-                # Define and Convert the record to namedtuple
-                namedtuple_type = namedtuple('Record', field_names)
-                temp_comment_changesets_for_process = namedtuple_type(*records[i]) # namedtuple type
-                process_status = 'Unknown'
-                changeset_properties = None
-                print(f"[{strftime('%m/%d/%Y %H:%M:%S', localtime())}] Remainings: {str(record_count)}. Process row number {temp_comment_changesets_for_process.row_num}...", end="", flush=True)
-
-                lookup_hash_id = temp_comment_changesets_for_process.q2_hash_id
-                
-                # Case when the row_num is same as previous:
-                # How: (1) multiple `Bugzilla_ID` (row_num: 79190) - A changeset link found in multiple bugzilla pages.
-                if prev_temp_comment_changesets_for_process and (temp_comment_changesets_for_process.row_num == prev_temp_comment_changesets_for_process.row_num):
-                    # Check the bug ids from the previous processed changeset to see if they are found in the title or not. If not in title, we can save this bug id for the current processed record.
-                    process_status = "Skipped: Dup q1.row_num"
-                    # Assuming that the current 'temp_comment_changesets_for_process' record has similar changeset than previous one:
-                    if prev_changeset_properties and prev_changeset_properties.hash_id and not temp_comment_changesets_for_process.q2_hash_id:
-                        lookup_hash_id = prev_changeset_properties.hash_id
-                
-                # Cases when current hash id is same as previous hash id (which means it has been processed):
-                # How: multiple `q2_mercurial_type` and/or `Bugzilla_ID`
-                elif prev_temp_comment_changesets_for_process and (prev_temp_comment_changesets_for_process.q1_hash_id.startswith(temp_comment_changesets_for_process.q1_hash_id) or temp_comment_changesets_for_process.q1_hash_id.startswith(prev_temp_comment_changesets_for_process.q1_hash_id)):
-                    process_status = "Skipped: Dup q1_hash_id"
-                    # Assuming that the current 'temp_comment_changesets_for_process' record has similar changeset than previous one:
-                    if prev_changeset_properties and prev_changeset_properties.hash_id and not temp_comment_changesets_for_process.q2_hash_id:
-                        lookup_hash_id = prev_changeset_properties.hash_id
+                    lookup_hash_id = temp_comment_changesets_for_process.q2_hash_id
+                    
+                    # Case when the row_num is same as previous:
+                    # How: (1) multiple `Bugzilla_ID` (row_num: 79190) - A changeset link found in multiple bugzilla pages.
+                    if prev_temp_comment_changesets_for_process and (temp_comment_changesets_for_process.row_num == prev_temp_comment_changesets_for_process.row_num):
+                        # Check the bug ids from the previous processed changeset to see if they are found in the title or not. If not in title, we can save this bug id for the current processed record.
+                        process_status = "Skipped: Dup q1.row_num"
+                        # Assuming that the current 'temp_comment_changesets_for_process' record has similar changeset than previous one:
+                        if prev_changeset_properties and prev_changeset_properties.hash_id and not temp_comment_changesets_for_process.q2_hash_id:
+                            lookup_hash_id = prev_changeset_properties.hash_id
+                    
+                    # Cases when current hash id is same as previous hash id (which means it has been processed):
+                    # How: multiple `q2_mercurial_type` and/or `Bugzilla_ID`
+                    elif prev_temp_comment_changesets_for_process and (prev_temp_comment_changesets_for_process.q1_hash_id.startswith(temp_comment_changesets_for_process.q1_hash_id) or temp_comment_changesets_for_process.q1_hash_id.startswith(prev_temp_comment_changesets_for_process.q1_hash_id)):
+                        process_status = "Skipped: Dup q1_hash_id"
+                        # Assuming that the current 'temp_comment_changesets_for_process' record has similar changeset than previous one:
+                        if prev_changeset_properties and prev_changeset_properties.hash_id and not temp_comment_changesets_for_process.q2_hash_id:
+                            lookup_hash_id = prev_changeset_properties.hash_id
 
 
-                # Get record of bugzilla_changeset by q2 hash id.
-                existing_bug_mozilla_changeset = get_bugzilla_mozilla_changesets_by_hash_id(lookup_hash_id)
+                    # Get record of bugzilla_changeset by q2 hash id.
+                    existing_bug_mozilla_changeset = get_bugzilla_mozilla_changesets_by_hash_id(lookup_hash_id)
 
 
-                if process_status != 'Unknown':
-                    pass  # Do nothing
-                elif existing_bug_mozilla_changeset:
-                    process_status = "Already Processed"
+                    if process_status != 'Unknown':
+                        pass  # Do nothing
+                    elif existing_bug_mozilla_changeset:
+                        process_status = "Already Processed"
 
-                # Cases when we want to make a web request to scrap changeset info:
-                # Cover cases: (1) When q2 doesn't exist. (2) When it's not backout related changesets. (3) When bug_id='' (No bug id found in changeset title - We process it if it found in the bug comment).
-                # Handle: (1) When hash id is a changeset number.
-                # Goal: we don't want to scrap the changeset link again if it has been done.
-                elif not temp_comment_changesets_for_process.q2_parent_hashes and (temp_comment_changesets_for_process.q2_is_backed_out_changeset == False or temp_comment_changesets_for_process.q2_backed_out_by == None or temp_comment_changesets_for_process.q2_backed_out_by == ''):
-                    # Make web request to get changeset properties:
-                    changeset_properties = get_changeset_properties_rev(temp_comment_changesets_for_process.q1_full_link)
+                    # Cases when we want to make a web request to scrap changeset info:
+                    # Cover cases: (1) When q2 doesn't exist. (2) When it's not backout related changesets. (3) When bug_id='' (No bug id found in changeset title - We process it if it found in the bug comment).
+                    # Handle: (1) When hash id is a changeset number.
+                    # Goal: we don't want to scrap the changeset link again if it has been done.
+                    elif not temp_comment_changesets_for_process.q2_parent_hashes and (temp_comment_changesets_for_process.q2_is_backed_out_changeset == False or temp_comment_changesets_for_process.q2_backed_out_by == None or temp_comment_changesets_for_process.q2_backed_out_by == ''):
+                        # Make web request to get changeset properties:
+                        changeset_properties = get_changeset_properties_rev(temp_comment_changesets_for_process.q1_full_link)
 
-                    # Just to be safe, make another call to get 'bugzilla_mozilla_changesets' but 'changeset_properties.hash_id' in case q2.hash_id incorrect:
-                    if changeset_properties.response_status_code == 200 and not existing_bug_mozilla_changeset:
-                        existing_bug_mozilla_changeset = get_bugzilla_mozilla_changesets_by_hash_id(changeset_properties.hash_id)
+                        # Just to be safe, make another call to get 'bugzilla_mozilla_changesets' but 'changeset_properties.hash_id' in case q2.hash_id incorrect:
+                        if changeset_properties.response_status_code == 200 and not existing_bug_mozilla_changeset:
+                            existing_bug_mozilla_changeset = get_bugzilla_mozilla_changesets_by_hash_id(changeset_properties.hash_id)
 
-                    # Determine the process_status for processed changeset:
-                    if changeset_properties.response_status_code == 404:
-                        process_status = "Processed: 404"
-                    elif changeset_properties.response_status_code == -1:
-                        process_status = "Failed Url - Human Intervention"
-                    elif (not changeset_properties.bug_ids_from_summary or changeset_properties.bug_ids_from_summary == '') and (not temp_comment_changesets_for_process.q2_bug_ids or temp_comment_changesets_for_process.q2_bug_ids == ''):
-                        process_status = "Processed: No Bug Ids in Changeset Title"
-                    elif changeset_properties.backed_out_by:
-                        process_status = "Processed: Backed Out By" 
-                    elif changeset_properties.is_backed_out_changeset:
-                        process_status = "Processed: Backout Changeset"
+                        # Determine the process_status for processed changeset:
+                        if changeset_properties.response_status_code == 404:
+                            process_status = "Processed: 404"
+                        elif changeset_properties.response_status_code == -1:
+                            process_status = "Failed Url - Human Intervention"
+                        elif (not changeset_properties.bug_ids_from_summary or changeset_properties.bug_ids_from_summary == '') and (not temp_comment_changesets_for_process.q2_bug_ids or temp_comment_changesets_for_process.q2_bug_ids == ''):
+                            process_status = "Processed: No Bug Ids in Changeset Title"
+                        elif changeset_properties.backed_out_by:
+                            process_status = "Processed: Backed Out By" 
+                        elif changeset_properties.is_backed_out_changeset:
+                            process_status = "Processed: Backout Changeset"
+                        else:
+                            process_status = "Processed"
+                    
+                    # save to database:
+                    save_comment_changeset_properties(process_status, temp_comment_changesets_for_process, changeset_properties, existing_bug_mozilla_changeset)
+
+                    # Make another call to database to check making sure it's actually done. Found that some cases, the data weren't saved to the db, not sure why:
+                    if is_temp_comment_changeset_done(temp_comment_changesets_for_process.id):
+                        # Update previous record
+                        prev_temp_comment_changesets_for_process = temp_comment_changesets_for_process
+                        if process_status.startswith("Processed"):
+                            prev_changeset_properties = changeset_properties
+
+                        print(f"{process_status}")
+                        remaining_records = total_records - i - 1
+                        re_run_iteration_count = 1
+                        
+                        break;
                     else:
-                        process_status = "Processed"
-                
-                # save to database:
-                save_comment_changeset_properties(process_status, temp_comment_changesets_for_process, changeset_properties, existing_bug_mozilla_changeset)
-
-                # Update previous record
-                prev_temp_comment_changesets_for_process = temp_comment_changesets_for_process
-                if process_status.startswith("Processed"):
-                    prev_changeset_properties = changeset_properties
-
-                print("Done")
-                record_count = record_count - 1
+                        time.sleep(3)
+                        print(f"Record didn't save to database, Re-do it. Attempt: {re_run_iteration_count}/5")
+                        re_run_iteration_count = re_run_iteration_count + 1
+                        continue;
 
 
 
 ##################################################################################################### 
 
 if __name__ == "__main__":
-    # parser = argparse.ArgumentParser(description="")
-    # parser.add_argument('arg_1', type=int, help='Argument 1')
-    # parser.add_argument('arg_2', type=int, help='Arg ument 2')
-    # parser.add_argument('arg_3', type=int, help='Argument 3')
-    # parser_args = parser.parse_args()
-    # task_group = parser_args.arg_1
-    # start_row = parser_args.arg_2
-    # end_row = parser_args.arg_3
+    parser = argparse.ArgumentParser(description="")
+    parser.add_argument('arg_1', type=int, help='Argument 1')
+    parser.add_argument('arg_2', type=int, help='Arg ument 2')
+    parser.add_argument('arg_3', type=int, help='Argument 3')
+    parser_args = parser.parse_args()
+    task_group = parser_args.arg_1
+    start_row = parser_args.arg_2
+    end_row = parser_args.arg_3
 
     # Testing specific input arguments:
-    task_group = 1   # Task group
-    start_row = 6193   # Start row
-    end_row = 6194   # End row
+    # task_group = 1   # Task group
+    # start_row = 0   # Start row
+    # end_row = 12500   # End row
     
     start_scraper(task_group, start_row, end_row, 'Changesets_From_Comments')
 

--- a/Bugzilla/Bugzilla_mozilla_changeset_contents_scraper.py
+++ b/Bugzilla/Bugzilla_mozilla_changeset_contents_scraper.py
@@ -1142,8 +1142,8 @@ def start_scraper(task_group, start_row, end_row, scraper_type):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="")
     parser.add_argument('arg_1', type=int, help='Argument 1')
-    parser.add_argument('arg_2', type=int, help='Arg ument 3')
-    parser.add_argument('arg_3', type=int, help='Argument 4')
+    parser.add_argument('arg_2', type=int, help='Arg ument 2')
+    parser.add_argument('arg_3', type=int, help='Argument 3')
     parser_args = parser.parse_args()
     task_group = parser_args.arg_1
     start_row = parser_args.arg_2
@@ -1157,4 +1157,3 @@ if __name__ == "__main__":
     start_scraper(task_group, start_row, end_row, 'Changesets_From_Comments')
 
 print(f"[{strftime('%m/%d/%Y %H:%M:%S', localtime())}] PROGRAM FINISHED. EXIT!")
-

--- a/Bugzilla/Bugzilla_mozilla_changeset_contents_scraper.py
+++ b/Bugzilla/Bugzilla_mozilla_changeset_contents_scraper.py
@@ -1139,19 +1139,19 @@ def start_scraper(task_group, start_row, end_row, scraper_type):
 ##################################################################################################### 
 
 if __name__ == "__main__":
-    # parser = argparse.ArgumentParser(description="")
-    # parser.add_argument('arg_1', type=int, help='Argument 1')
-    # parser.add_argument('arg_2', type=int, help='Argument 2')
-    # parser.add_argument('arg_3', type=int, help='Argument 3')
-    # parser_args = parser.parse_args()
-    # task_group = parser_args.arg_1
-    # start_row = parser_args.arg_2
-    # end_row = parser_args.arg_3
+    parser = argparse.ArgumentParser(description="")
+    parser.add_argument('arg_1', type=int, help='Argument 1')
+    parser.add_argument('arg_2', type=int, help='Argument 2')
+    parser.add_argument('arg_3', type=int, help='Argument 3')
+    parser_args = parser.parse_args()
+    task_group = parser_args.arg_1
+    start_row = parser_args.arg_2
+    end_row = parser_args.arg_3
 
     # Testing specific input arguments:
-    task_group = 2   # Task group
-    start_row = 0   # Start row
-    end_row = 12500   # End row
+    # task_group = 2   # Task group
+    # start_row = 0   # Start row
+    # end_row = 12500   # End row
     
     start_scraper(task_group, start_row, end_row, 'Changesets_From_Comments')
 

--- a/Bugzilla/Bugzilla_mozilla_changeset_contents_scraper.py
+++ b/Bugzilla/Bugzilla_mozilla_changeset_contents_scraper.py
@@ -1139,19 +1139,19 @@ def start_scraper(task_group, start_row, end_row, scraper_type):
 ##################################################################################################### 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="")
-    parser.add_argument('arg_1', type=int, help='Argument 1')
-    parser.add_argument('arg_2', type=int, help='Argument 2')
-    parser.add_argument('arg_3', type=int, help='Argument 3')
-    parser_args = parser.parse_args()
-    task_group = parser_args.arg_1
-    start_row = parser_args.arg_2
-    end_row = parser_args.arg_3
+    # parser = argparse.ArgumentParser(description="")
+    # parser.add_argument('arg_1', type=int, help='Argument 1')
+    # parser.add_argument('arg_2', type=int, help='Argument 2')
+    # parser.add_argument('arg_3', type=int, help='Argument 3')
+    # parser_args = parser.parse_args()
+    # task_group = parser_args.arg_1
+    # start_row = parser_args.arg_2
+    # end_row = parser_args.arg_3
 
     # Testing specific input arguments:
-    # task_group_start = 1   # Task group
-    # start_row = 0   # Start row
-    # end_row = 12500   # End row
+    task_group = 2   # Task group
+    start_row = 0   # Start row
+    end_row = 12500   # End row
     
     start_scraper(task_group, start_row, end_row, 'Changesets_From_Comments')
 


### PR DESCRIPTION
I have noticed that sometimes the data wasn't saved in the database. However, if we re-run the current iteration, it is saved. I'm not exactly sure why, but I added the check at the end of each iteration to check the database to ensure that the data are saved appropriately.